### PR TITLE
Add vCard generation and QR code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # VCF Digital Name Card
 
 This is a frontend-only React application for creating and sharing a digital business card.
+Users can enter their details, preview the card, download a `.vcf` file and get a QR code that encodes the vCard text for quick import on mobile devices.
 
 ## Development
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import CardPreview from './components/CardPreview'
 import QRCodeDisplay from './components/QRCodeDisplay'
 import DownloadButtons from './components/DownloadButtons'
 import ViewCard from './pages/ViewCard'
+import generateVcf from './utils/vcfGenerator'
 import './App.css'
 
 export default function App() {
@@ -29,6 +30,7 @@ export default function App() {
 
   const encodedData = btoa(JSON.stringify(data))
   const shareUrl = `${window.location.origin}/card?data=${encodedData}`
+  const vcfString = generateVcf(data)
 
   return (
     <BrowserRouter>
@@ -45,11 +47,11 @@ export default function App() {
                     Share Link
                   </a>
                 </div>
-                <DownloadButtons data={data} cardRef={cardRef} qrValue={shareUrl} />
+                <DownloadButtons data={data} cardRef={cardRef} qrValue={vcfString} />
               </div>
               <div className="flex flex-col items-center space-y-4">
                 <CardPreview data={data} refProp={cardRef} />
-                <QRCodeDisplay value={shareUrl} />
+                <QRCodeDisplay value={vcfString} />
               </div>
             </div>
           )}

--- a/src/components/DownloadButtons.jsx
+++ b/src/components/DownloadButtons.jsx
@@ -1,9 +1,10 @@
 import { toPng } from 'html-to-image'
 import { saveAs } from 'file-saver'
+import generateVcf from '../utils/vcfGenerator'
 
 export default function DownloadButtons({ data, cardRef, qrValue }) {
   const downloadVcf = () => {
-    const vcfContent = `BEGIN:VCARD\nVERSION:3.0\nFN:${data.name}\nTITLE:${data.title}\nORG:${data.company}\nTEL;TYPE=WORK,VOICE:${data.phone}\nEMAIL:${data.email}\nURL:${data.link}\nEND:VCARD`
+    const vcfContent = generateVcf(data)
     const blob = new Blob([vcfContent], { type: 'text/vcard;charset=utf-8' })
     saveAs(blob, `${data.name || 'contact'}.vcf`)
   }

--- a/src/utils/vcfGenerator.js
+++ b/src/utils/vcfGenerator.js
@@ -1,0 +1,29 @@
+export default function generateVcf(data) {
+  const {
+    name = '',
+    title = '',
+    company = '',
+    phone = '',
+    email = '',
+    link = '',
+  } = data || {};
+
+  const parts = name.trim().split(' ');
+  const firstName = parts.shift() || '';
+  const lastName = parts.join(' ');
+
+  const lines = [
+    'BEGIN:VCARD',
+    'VERSION:3.0',
+    `N:${lastName};${firstName};;;`,
+    `FN:${name}`,
+    company && `ORG:${company}`,
+    title && `TITLE:${title}`,
+    phone && `TEL;TYPE=CELL:${phone}`,
+    email && `EMAIL:${email}`,
+    link && `URL:${link}`,
+    'END:VCARD',
+  ].filter(Boolean);
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Summary
- generate vCard text from user data
- display QR code using the vCard string
- export the same vCard via Download buttons
- document vCard/QR capability

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e93473c5c8333af6b0097195de1fe